### PR TITLE
Copy error stream to byte array to avoid premature stream consuming

### DIFF
--- a/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
@@ -36,8 +36,25 @@ public class HttpClientTest extends BaseRestTest {
 		int i = service.returnPrimitiveInt(2);
 		Assert.assertEquals(2, i);
 	}
-	
-	@Override
+
+	@Test
+	public void testErrorResponseChecking() throws MalformedURLException {
+		expectedEx.expectMessage("<html>\n" +
+				"<head>\n" +
+				"<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"/>\n" +
+				"<title>Error 405 HTTP method POST is not supported by this URL</title>\n" +
+				"</head>\n" +
+				"<body><h2>HTTP ERROR 405</h2>\n" +
+				"<p>Problem accessing /error. Reason:\n" +
+				"<pre>    HTTP method POST is not supported by this URL</pre></p><hr><a href=\"http://eclipse.org/jetty\">Powered by Jetty:// 9.4.0.RC3</a><hr/>\n" +
+				"\n" +
+				"</body>\n" +
+				"</html>\n");
+		service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient("error"));
+		service.doSomething();
+	}
+
+    @Override
 	protected Class service() {
 		return FakeServiceInterfaceImpl.class;
 	}

--- a/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
@@ -51,6 +51,11 @@ public abstract class BaseRestTest {
 		Map<String, String> header = new HashMap<>();
 		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(JettyServer.SERVLET)), header, gzipRequests, acceptGzipResponses);
 	}
+
+	protected JsonRpcHttpClient getHttpClient(final String servlet) throws MalformedURLException {
+		Map<String, String> header = new HashMap<>();
+		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(servlet)), header);
+	}
 	
 	@After
 	public void teardown() throws Exception {


### PR DESCRIPTION
1) Copy error stream to byte array to avoid premature stream consuming
2) Test for error response checking in `JsonRpcHttpClient`