### PR TITLE
Avoid premature errorStream consuming in JsonRpcHttpClient

### DIFF
--- a/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
@@ -1,5 +1,6 @@
 package com.googlecode.jsonrpc4j.integration;
 
+import com.googlecode.jsonrpc4j.JsonRpcClientException;
 import com.googlecode.jsonrpc4j.ProxyUtil;
 import com.googlecode.jsonrpc4j.util.BaseRestTest;
 import com.googlecode.jsonrpc4j.util.FakeServiceInterface;
@@ -8,6 +9,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * HttpClientTest
@@ -36,7 +40,25 @@ public class HttpClientTest extends BaseRestTest {
 		int i = service.returnPrimitiveInt(2);
 		Assert.assertEquals(2, i);
 	}
-	
+
+	@Test
+	public void testCustomException() throws Exception {
+		expectedEx.expectMessage(equalTo("Custom exception"));
+		expectedEx.expect(JsonRpcClientException.class);
+
+		service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient(false, false));
+		service.throwSomeException("Custom exception");
+	}
+
+	@Test
+	public void testHttpError() throws Exception {
+		expectedEx.expectMessage(containsString("405 HTTP method POST is not supported by this URL"));
+		expectedEx.expect(Exception.class);
+
+		service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient("error", false, false));
+		service.doSomething();
+	}
+
 	@Override
 	protected Class service() {
 		return FakeServiceInterfaceImpl.class;

--- a/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
@@ -51,6 +51,11 @@ public abstract class BaseRestTest {
 		Map<String, String> header = new HashMap<>();
 		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(JettyServer.SERVLET)), header, gzipRequests, acceptGzipResponses);
 	}
+
+	protected JsonRpcHttpClient getHttpClient(final String servlet, boolean gzipRequests, boolean acceptGzipResponses) throws MalformedURLException {
+		Map<String, String> header = new HashMap<>();
+		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(servlet)), header, gzipRequests, acceptGzipResponses);
+	}
 	
 	@After
 	public void teardown() throws Exception {


### PR DESCRIPTION
1) Avoid premature stream consuming
2) Test fot HTTP error and JSON-RPC error
author @klya